### PR TITLE
fix the mapping between on and off

### DIFF
--- a/blinkpy/helpers/camera.py
+++ b/blinkpy/helpers/camera.py
@@ -26,7 +26,7 @@ def set_night_vision(camera, to="auto"):
          Possible states are 'on', 'off', and 'auto'
     """
     if camera.product_type == "catalina":
-        to = {"off": 0, "on": 1, "auto": 2}.get(to, None)
+        to = {"on": 0, "off": 1, "auto": 2}.get(to, None)
     if camera.product_type == "owl" and to in ["auto", "on", "off"]:
         url = f"{camera.sync.urls.base_url}/api/v1/accounts/{camera.sync.blink.account_id}/networks/{camera.network_id}/owls/{camera.camera_id}/config"
     elif camera.product_type == "catalina" and to in [0, 1, 2]:


### PR DESCRIPTION
fix the mapping between on and off 
[Previously]
set_night_vision(camera, to="on") activates rgb camera. [Now]
set_night_vision(camera, to="on") activates ir camera.

## Description:


**Related issue (if applicable):** fixes #<blinkpy issue number goes here>

## Checklist:
- [ ] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [ ] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
